### PR TITLE
feature/fixing-url-param-resource-id 

### DIFF
--- a/assets/src/components/redirect-button.js
+++ b/assets/src/components/redirect-button.js
@@ -15,7 +15,8 @@ function RedirectButton({ calendarSelection, config }) {
     const paramsObj = {
       from: calendarSelection.start.toISOString(),
       to: calendarSelection.end.toISOString(),
-      resource: calendarSelection.resource.extendedProps.resourceId ?? undefined,
+      resource:
+        calendarSelection.resource.extendedProps.resourceId ?? undefined,
     };
     if (
       paramsObj.from === undefined ||
@@ -38,6 +39,11 @@ function RedirectButton({ calendarSelection, config }) {
 
 RedirectButton.propTypes = {
   calendarSelection: PropTypes.shape({
+    resource: PropTypes.shape({
+      extendedProps: PropTypes.shape({
+        resourceId: PropTypes.number.isRequired,
+      }).isRequired,
+    }).isRequired,
     start: PropTypes.shape({
       toISOString: PropTypes.func.isRequired,
     }).isRequired,

--- a/assets/src/components/redirect-button.js
+++ b/assets/src/components/redirect-button.js
@@ -15,7 +15,7 @@ function RedirectButton({ calendarSelection, config }) {
     const paramsObj = {
       from: calendarSelection.start.toISOString(),
       to: calendarSelection.end.toISOString(),
-      resource: calendarSelection.resourceId ?? undefined,
+      resource: calendarSelection.resource.extendedProps.resourceId ?? undefined,
     };
     if (
       paramsObj.from === undefined ||


### PR DESCRIPTION
modified redirect button to use resource id instead of mail, due to complications due to fcs naming-requirements in  mapping of events on resources