### PR TITLE
Hotfix/Sunday businesshours convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [keep a changelog](https://keepachangelog.com/en/1.0.0/) for information abo
 - Removed search text filtering [#126](https://github.com/itk-dev/drupal_webform_booking_module/pull/126).
 - Disabled sorting options since they do not apply [#126](https://github.com/itk-dev/drupal_webform_booking_module/pull/126).
 - Stopped event propagation and default for pagination buttons [#125](https://github.com/itk-dev/drupal_webform_booking_module/pull/125).
+- Converted internal notation of business hours for sunday from (7) to (0) [#128](https://github.com/itk-dev/drupal_webform_booking_module/pull/128)
 
 ## [1.0.7] - 2023-08-24
 

--- a/assets/src/util/calendar-utils.js
+++ b/assets/src/util/calendar-utils.js
@@ -119,7 +119,7 @@ export function handleResources(value, currentCalendarDate) {
       endTime: "24:00",
     };
   }
-  console.log(resource);
+
   return resource;
 }
 

--- a/assets/src/util/calendar-utils.js
+++ b/assets/src/util/calendar-utils.js
@@ -88,7 +88,7 @@ export function handleResources(value, currentCalendarDate) {
     const endTime = dayjs(v.close).format("HH:mm");
 
     const businessHours = {
-      daysOfWeek: [v.weekday],
+      daysOfWeek: [v.weekday === 7 ? 0 : v.weekday], // Sunday is internally defined as day 0, hence day 7 is converted to day 0 here.
       startTime: businessHoursOrNearestFifteenMinutes(startTime, currentCalendarDate, false),
       endTime,
     };
@@ -119,7 +119,7 @@ export function handleResources(value, currentCalendarDate) {
       endTime: "24:00",
     };
   }
-
+  console.log(resource);
   return resource;
 }
 


### PR DESCRIPTION
Link to ticket
https://jira.itkdev.dk/browse/SUPP0RT-1278

Description
Internally in Fullcalendar, sunday is defined as daysOfWeek[0], but we are defining it as daysOfWeek[7].
Hence, all resources are unavailable on sundays, as no businessHours exist.

This PR fixes this issue, by checking for day 7, converting it to day 0.
It does not seem possible to change the internal structure of this.

An alternative fix, could be to get MSB to update their SQL, but this solves the problem for now.